### PR TITLE
Add rule to remove `eldiario.es` consent modal

### DIFF
--- a/definitions/consent.json
+++ b/definitions/consent.json
@@ -18,5 +18,8 @@
   },
   "*.stackexchange.com *.superuser.com *.stackoverflow.com *.mathoverflow.net *.serverfault.com *.askubuntu.com *.stackapps.com": {
     ".js-consent-banner": "remove"
+  },
+  "*.eldiario.es": {
+    ".didomi-consent-popup__62f49e32-b476-46b4-9757-407895dd174e": "remove"
   }
 }

--- a/definitions/consent.json
+++ b/definitions/consent.json
@@ -20,6 +20,6 @@
     ".js-consent-banner": "remove"
   },
   "*.eldiario.es": {
-    ".didomi-consent-popup__62f49e32-b476-46b4-9757-407895dd174e": "remove"
+    "[class*='didomi-consent-popup__']": "remove"
   }
 }


### PR DESCRIPTION
Link: [eldiario.es](https://eldiario.es)

I am a bit unsure if the UUID at the end of the class name used for the rule will change in the future. Is there a way to select it using a wildcard?

Anyway here is the screenshot of the web

<img width="1516" alt="image" src="https://user-images.githubusercontent.com/4384330/150209229-b05772ad-ebf3-4130-8bc6-d673c8292a52.png">
