### PR TITLE
Add definition that removes chatbot from Pandora help pages

### DIFF
--- a/definitions/message.json
+++ b/definitions/message.json
@@ -9,6 +9,9 @@
     "if $([data-cy-id='careers-upsell'])": {
       "[data-cy-id='careers-upsell']": "removeParent"
     }
+  },
+  "help.pandora.com": {
+    "$(#bot-root)": "remove"
   }
 }
 


### PR DESCRIPTION
Added a definition to remove a chat bot that appears in the bottom-right-hand corner on all of the help webpages in the "help" subdomain of Pandora's (the streaming music service) website, "help.pandora.com".

<img width="372" alt="Screenshot - Pandora + Alexa - 02-18-2022" src="https://user-images.githubusercontent.com/66871387/154747364-3cefd29e-5031-4968-a5fa-2f75324447d2.png">