### PR TITLE
Added definitions for vk.com, redhat.com, ubuntu.com, canonical.com and more

### DIFF
--- a/definitions/consent.json
+++ b/definitions/consent.json
@@ -43,7 +43,7 @@
     ".js-consent-banner": "remove"
   },
   "*.deepl.com": {
-    ".dl_cookieBanner--buttonClose": "click"
+    "#dl_cookieBanner": "remove"
   },
   "*.lego.com": {
     ".cookies-used-notice": "remove"

--- a/definitions/consent.json
+++ b/definitions/consent.json
@@ -37,7 +37,10 @@
     "if $(#acceptationCMPWall)": {
       "#acceptationCMPWall": "remove",
       "body": "removeStyle"
-    }
+    },
+    ".cookies_message": "remove",
+    "#cookieConsent": "remove",
+    ".cookie-policy": "remove"
   },
   "*.stackexchange.com *.superuser.com *.stackoverflow.com *.mathoverflow.net *.serverfault.com *.askubuntu.com *.stackapps.com": {
     ".js-consent-banner": "remove"
@@ -47,5 +50,9 @@
   },
   "*.lego.com": {
     ".cookies-used-notice": "remove"
+  },
+  "*.redhat.com": {
+  	"#truste-consent-track": "remove",
+  	".redhat-cookie-banner": "remove"
   }
 }

--- a/definitions/email.json
+++ b/definitions/email.json
@@ -17,5 +17,8 @@
   },
   "*.npr.org": {
     ".newsletter-stickybar": "remove"
+  },
+  "*.redhat.com": {
+  	".subscribe-sidebar": "remove"
   }
 }

--- a/definitions/signup.json
+++ b/definitions/signup.json
@@ -58,5 +58,11 @@
       ".tp-modal": "remove",
       ".tp-backdrop": "remove"
     }
+  },
+  "vk.com": {
+  	"#page_bottom_banners_root": "remove",
+  	"if $(.UnauthActionBox)": {
+  		".JoinForm__notNowLink": "click"
+  	}
   }
 }


### PR DESCRIPTION
- Add definitions for `vk.com` (russian-speaking social network)
- Add definitions for `redhat.com`
- Add some common rules for (`ubuntu.com`, `canonical.com`, and `*.edusite.ru`)
- Update definition for `deepl.com`