### PR TITLE
Add weather.com definitions to paywall.json

### DIFF
--- a/definitions/paywall.json
+++ b/definitions/paywall.json
@@ -36,5 +36,16 @@
       "#fortress-paywall-container-root": "remove",
       "body": "addStyle overflow: auto"
     }
+  },
+  "*.weather.com": {
+    "if $(.tp-backdrop)": {
+      ".tp-backdrop": "remove"
+    },
+    "if $(.tp-modal)": {
+      ".tp-modal": "remove"
+    },
+    "if $(.tp-modal-open)": {
+      ".tp-modal-open": "removeClass tp-modal-open"
+    }
   }
 }


### PR DESCRIPTION
Removes paywall modal from weather.com.

Example test url: https://weather.com/weather/today/l/814cccae5a35eb448d2585b01999033fced9c4fa475ad736fc1d7ec76f253d68

<img width="965" alt="Screen Shot 2022-04-08 at 11 05 43 AM" src="https://user-images.githubusercontent.com/498293/162500824-af1a6ce7-dbad-4afb-a155-655b4b23d1d1.png">

